### PR TITLE
Add pickup points filter by tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Add Pickup Point filter by tag name
 
 ## [0.2.0] - 2020-10-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add Pickup Point filter by tag name
+
 ## [0.2.0] - 2020-10-06
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,11 +46,12 @@ A few interfaces may have properties available for extra customization.
 
 ### `store-list` and `store-map` props
 
-| Prop name    | Type     | Description               | Default value          |
-| ------------ | -------- | ------------------------- | ---------------------- |
-| `icon`       | `string` | Icon url (`svg` or `png`) | `Google's default`     |
-| `iconWidth`  | `number` | Number in pixels          | `Image default width`  |
-| `iconHeight` | `number` | Number in pixels          | `Image default height` |
+| Prop name     | Type     | Description                               | Default value          |
+| ------------- | -------- | ----------------------------------------- | ---------------------- |
+| `filterByTag` | `string` | Filter returned Pickup Points by tag name | `undefined`            |
+| `icon`        | `string` | Icon url (`svg` or `png`)                 | `Google's default`     |
+| `iconWidth`   | `number` | Number in pixels                          | `Image default width`  |
+| `iconHeight`  | `number` | Number in pixels                          | `Image default height` |
 
 ### `store-back-link` props
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,6 +1,10 @@
 type Query {
-  getStores(postalCode: String, pageNumber: Int, pageSize: Int): StoreResponse
-    @cacheControl(scope: PRIVATE)
+  getStores(
+    postalCode: String
+    pageNumber: Int
+    pageSize: Int
+    keyword: String
+  ): StoreResponse @cacheControl(scope: PRIVATE)
 }
 
 type StoreResponse {

--- a/node/utils/Hub.ts
+++ b/node/utils/Hub.ts
@@ -2,10 +2,10 @@
 import { ExternalClient, InstanceOptions, IOContext } from '@vtex/api'
 
 const routes = {
-  getAll: ({ pageNumber, pageSize }: any, account: string) =>
+  getAll: ({ pageNumber, pageSize, keyword }: any, account: string) =>
     `http://logistics.vtexcommercestable.com.br/api/logistics/pvt/configuration/pickuppoints/_search?an=${account}&page=${
       pageNumber ?? 1
-    }&pageSize=${pageSize ?? 50}`,
+    }&pageSize=${pageSize ?? 50}&keyword=${keyword ?? ''}`,
   getByLocation: (
     { postalCode, countryCode, pageNumber, pageSize }: any,
     account: string

--- a/react/List.tsx
+++ b/react/List.tsx
@@ -26,6 +26,7 @@ const CSS_HANDLES = [
 const StoreList = ({
   orderForm: { called: ofCalled, loading: ofLoading, orderForm: ofData },
   googleMapsKeys,
+  filterByTag,
   icon,
   iconWidth,
   iconHeight,
@@ -50,6 +51,7 @@ const StoreList = ({
         postalCode: null,
         pageNumber: 1,
         pageSize: 50,
+        filterByTag,
       },
     })
   }
@@ -61,6 +63,7 @@ const StoreList = ({
           postalCode: ofData.shippingData.address.postalCode,
           pageNumber: 1,
           pageSize: 50,
+          filterByTag,
         },
       })
     } else {

--- a/react/queries/getStores.gql
+++ b/react/queries/getStores.gql
@@ -1,8 +1,14 @@
-query getStores($postalCode: String, $pageNumber: Int, $pageSize: Int) {
+query getStores(
+  $postalCode: String
+  $pageNumber: Int
+  $pageSize: Int
+  $filterByTag: String
+) {
   getStores(
     postalCode: $postalCode
     pageNumber: $pageNumber
     pageSize: $pageSize
+    keyword: $filterByTag
   ) {
     items {
       distance

--- a/react/queries/getStores.gql
+++ b/react/queries/getStores.gql
@@ -3,7 +3,7 @@ query getStores(
   $pageNumber: Int
   $pageSize: Int
   $filterByTag: String
-) {
+) @context(provider: "vtex.store-locator") {
   getStores(
     postalCode: $postalCode
     pageNumber: $pageNumber


### PR DESCRIPTION
#### What problem is this solving?

Filter Pickup Point locations by a tag name 

#### How to test it?

Add filter to theme:

```diff
  "store-list": {
+    "props": {"filterByTag": "StoreLocator"}
  },
```
Configure Pickup Points:

![Screenshot from 2020-10-27 15-05-45](https://user-images.githubusercontent.com/22715037/97349609-0dab6800-1866-11eb-9e7d-9c3fdc974acf.png)

[Workspace](https://filterbytag--eriksbikeshop.myvtex.com/stores)

#### Screenshots or example usage:

![Screenshot from 2020-10-27 15-07-47](https://user-images.githubusercontent.com/22715037/97349747-3895bc00-1866-11eb-818a-7a43d4c1b1a9.png)

