### PR TITLE
Additions to Store Hours and Store Name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CSS selector for Store Instructions text
+- Display closed days in Store Hours
+- Add optional text prop to Store Name
+
 ## [0.3.0] - 2020-10-27
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,7 @@ You can use our default [blocks.json](https://github.com/vtex-apps/store-locator
 | `hoursLabel`            |
 | `instructionsContainer` |
 | `instructionsLabel`     |
+| `instructionsText`      |
 | `listingMapContainer`   |
 | `loadAll`               |
 | `markerInfoAddress`     |

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,9 +68,10 @@ A few interfaces may have properties available for extra customization.
 
 ### `store-name` props
 
-| Prop name | Type     | Description                                                                             | Default value |
-| --------- | -------- | --------------------------------------------------------------------------------------- | ------------- |
-| `text`    | `string` | Optional text to display with store name. Use `{storeName}` to display the store's name | `{storeName}` |
+| Prop name | Type     | Description                                                                                     | Default value |
+| --------- | -------- | ----------------------------------------------------------------------------------------------- | ------------- |
+| `text`    | `string` | Text to display with store name. Use `{storeName}` to display the store's name within your text | `{storeName}` |
+| `tag`     | `string` | HTML element to wrap store name block                                                           | `div`         |
 
 ### `store-address` props
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,12 @@ A few interfaces may have properties available for extra customization.
 | `width`   | `string` | Map width   | `100%`        |
 | `height`  | `string` | Map height  | `200px`       |
 
+### `store-name` props
+
+| Prop name | Type     | Description                                                                             | Default value |
+| --------- | -------- | --------------------------------------------------------------------------------------- | ------------- |
+| `text`    | `string` | Optional text to display with store name. Use `{storeName}` to display the store's name | `{storeName}` |
+
 ### `store-address` props
 
 | Prop name | Type     | Description                 | Default value   |

--- a/messages/context.json
+++ b/messages/context.json
@@ -5,6 +5,7 @@
   "store/back-link": "store/back-link",
   "store/address-label": "store/address-label",
   "store/information-label": "store/information-label",
+  "store/store-closed": "store/store-closed",
   "store/hours-label": "store/hours-label",
   "store/day-of-week-sunday": "store/day-of-week-sunday",
   "store/day-of-week-monday": "store/day-of-week-monday",

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,6 +5,7 @@
   "store/back-link": "Back to all stores",
   "store/address-label": "Store address",
   "store/information-label": "Information",
+  "store/store-closed": "Closed",
   "store/hours-label": "Store hours",
   "store/day-of-week-sunday": "Sunday",
   "store/day-of-week-monday": "Monday",

--- a/messages/es.json
+++ b/messages/es.json
@@ -5,6 +5,7 @@
   "store/back-link": "Volver a todas las tiendas",
   "store/address-label": "Dirección de la tienda",
   "store/information-label": "Información",
+  "store/store-closed": "Cerrado",
   "store/hours-label": "Horario de la tienda",
   "store/day-of-week-sunday": "Domingo",
   "store/day-of-week-monday": "Lunes",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -5,6 +5,7 @@
   "store/back-link": "Voltar para lista de lojas",
   "store/address-label": "Endereço",
   "store/information-label": "Informações",
+  "store/store-closed": "Fechado",
   "store/hours-label": "Horário de funcionamento",
   "store/day-of-week-sunday": "Domingo",
   "store/day-of-week-monday": "Segunda",

--- a/node/package.json
+++ b/node/package.json
@@ -13,7 +13,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.36.3",
+    "@vtex/api": "6.37.0",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -165,10 +165,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.36.3":
-  version "6.36.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.36.3.tgz#d827944829fb289d3a826cac12874f8e33ce62f5"
-  integrity sha512-i7zZ0Mj5pGEr6wd8VCK/hhiKTmmiuTn44v9MlWn36MRvtfBfOsKlhMFUEv3HBT1MH+fQTNM9vY08uSy7BsG44w==
+"@vtex/api@6.37.0":
+  version "6.37.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.0.tgz#a07e6adbfc02866f901cf0cfff2155f2c279adc5"
+  integrity sha512-Vy970ZfgOttrxeiJW2oM8rQ0E8t/HE5cQhbGIawfJsu35HEWA9NnWRSR3bdLMczT9oYIY9QwE8IfdU4b44dhKw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1402,7 +1402,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/StoreHours.tsx
+++ b/react/StoreHours.tsx
@@ -11,6 +11,10 @@ const messages = defineMessages({
     defaultMessage: 'Store hours',
     id: 'store/hours-label',
   },
+  storeClosed: {
+    defaultMessage: 'Closed',
+    id: 'store/store-closed',
+  },
   '0': {
     defaultMessage: 'Sunday',
     id: 'store/day-of-week-sunday',
@@ -51,6 +55,10 @@ const CSS_HANDLES = [
 ] as const
 
 const timeFormat = (time: string, format?: string) => {
+  if (!time) {
+    return ''
+  }
+
   const [hour, minute] = time.split(':')
 
   if (format?.toLocaleLowerCase() === '12h') {
@@ -74,6 +82,17 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
     return null
   }
 
+  const displayHours = (item) => {
+    const open = timeFormat(item.openingTime, format)
+    const close = timeFormat(item.closingTime, format)
+
+    if (!open && !close) {
+      return intl.formatMessage(messages.storeClosed)
+    }
+
+    return `${open} - ${close}`
+  }
+
   return (
     <div className={handles.hoursContainer}>
       <span className={`b ${handles.hoursLabel}`}>
@@ -82,15 +101,17 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
       <br />
       {group.businessHours.map((item: any, i: number) => {
         return (
-          <div key={`hour_${i}`} className={handles.hourRow}>
-            <span className={handles.dayOfWeek}>
+          <div
+            key={`hour_${i}`}
+            className={`${handles.hourRow} mv1 flex flex-wrap`}
+          >
+            <div className={`${handles.dayOfWeek} w-30`}>
               {intl.formatMessage(messages[item.dayOfWeek])}
-            </span>
-            <span className={handles.divider}>:</span>
-            <span className={handles.businessHours}>
-              {timeFormat(item.openingTime, format)}
-              {` - `} {timeFormat(item.closingTime, format)}
-            </span>
+              <span className={handles.divider}>:</span>
+            </div>
+            <div className={`${handles.businessHours} tc w-50`}>
+              {displayHours(item)}
+            </div>
           </div>
         )
       })}

--- a/react/StoreInstructions.tsx
+++ b/react/StoreInstructions.tsx
@@ -4,7 +4,12 @@ import { useCssHandles } from 'vtex.css-handles'
 
 import { useStoreGroup } from './StoreGroup'
 
-const CSS_HANDLES = ['instructionsContainer', 'instructionsLabel'] as const
+const CSS_HANDLES = [
+  'instructionsContainer',
+  'instructionsLabel',
+  'instructionsText',
+] as const
+
 const messages = defineMessages({
   information: {
     defaultMessage: 'Information',
@@ -32,7 +37,7 @@ const StoreInstructions: FC<StoreInstructionsProps & WrappedComponentProps> = ({
       <span className={handles.instructionsLabel}>
         {label ?? intl.formatMessage(messages.information)}
       </span>
-      {group.instructions}
+      <span className={handles.instructionsText}>{group.instructions}</span>
     </div>
   )
 }

--- a/react/StoreName.tsx
+++ b/react/StoreName.tsx
@@ -1,15 +1,12 @@
 import React, { FC } from 'react'
+import PropTypes from 'prop-types'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { useStoreGroup } from './StoreGroup'
 
 const CSS_HANDLES = ['storeName'] as const
 
-interface StoreNameProps {
-  text: string
-}
-
-const StoreName: FC<StoreNameProps> = ({ text }) => {
+const StoreName: FC<StoreNameProps> = ({ text, tag }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const group = useStoreGroup()
 
@@ -17,15 +14,30 @@ const StoreName: FC<StoreNameProps> = ({ text }) => {
     return null
   }
 
+  const Wrapper = tag as keyof JSX.IntrinsicElements
   const parseText = (string: string) => {
-    return string.replace(/{store-name}/gi, group.friendlyName)
+    return string.replace(/{storeName}/gi, group.friendlyName)
   }
 
   return (
-    <h1 className={handles.storeName}>
+    <Wrapper className={handles.storeName}>
       {text ? parseText(text) : group.friendlyName}
-    </h1>
+    </Wrapper>
   )
+}
+
+interface StoreNameProps {
+  text?: string
+  tag?: string
+}
+
+StoreName.defaultProps = {
+  tag: 'div',
+}
+
+StoreName.propTypes = {
+  text: PropTypes.string,
+  tag: PropTypes.string,
 }
 
 export default StoreName

--- a/react/StoreName.tsx
+++ b/react/StoreName.tsx
@@ -1,11 +1,15 @@
-import React from 'react'
+import React, { FC } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { useStoreGroup } from './StoreGroup'
 
 const CSS_HANDLES = ['storeName'] as const
 
-const StoreName = () => {
+interface StoreNameProps {
+  text: string
+}
+
+const StoreName: FC<StoreNameProps> = ({ text }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const group = useStoreGroup()
 
@@ -13,7 +17,15 @@ const StoreName = () => {
     return null
   }
 
-  return <div className={handles.storeName}>{group.friendlyName}</div>
+  const parseText = (string: string) => {
+    return string.replace(/{store-name}/gi, group.friendlyName)
+  }
+
+  return (
+    <h1 className={handles.storeName}>
+      {text ? parseText(text) : group.friendlyName}
+    </h1>
+  )
 }
 
 export default StoreName


### PR DESCRIPTION
#### What problem is this solving?

Some component changes based on app feedback.
[https://vtex-dev.atlassian.net/browse/U1PA-280?focusedCommentId=19739](https://vtex-dev.atlassian.net/browse/U1PA-280?focusedCommentId=19739)

Store Name component:
- Use `H1` tag for store name
- Add optional string prop and `{storeName}` variable parsing  

Store Hours component:
- Display closed days under store hours
- Add styling

Store Instructions component:
- CSS selector for Store Instructions text

#### How to test it?

[Workspace](https://sdb--eriksbikeshop.myvtex.com/store/rassys-west-des-moines-ia-50265/Desm)

#### Screenshots or example usage:

![Screenshot from 2020-11-04 08-10-52](https://user-images.githubusercontent.com/22715037/98128589-50c49700-1e75-11eb-82d3-a7b274aa47dc.png)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
