### PR TITLE
Error loading stores when user is identified but not logged in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Error loading stores when user is identified but not logged in
+
 ## [0.4.1] - 2020-11-16
 
 ### Added

--- a/react/List.tsx
+++ b/react/List.tsx
@@ -57,7 +57,10 @@ const StoreList = ({
   }
 
   if (ofCalled && !ofLoading && !called) {
-    if (ofData.shippingData?.address?.postalCode) {
+    if (
+      ofData.shippingData?.address?.postalCode &&
+      ofData.shippingData.address.postalCode.indexOf('*') !== -1
+    ) {
       getStores({
         variables: {
           postalCode: ofData.shippingData.address.postalCode,


### PR DESCRIPTION
#### What problem is this solving?
When the user is identified, its postalCode isn't totally available, it has invalid characters, this is causing an error 500 trying to load stores

<!--- What is the motivation and context for this change? -->

#### How to test it?
Go to the checkout, identify yourself using an email used before to place an order, go back to the store locator page

or simulate using the graphql interface

query getStores($postalCode: String, $pageNumber: Int, $pageSize: Int, $filterByTag: String) {
  getStores(postalCode: $postalCode, pageNumber: $pageNumber, pageSize: $pageSize, keyword: $filterByTag) {
    items {
      distance
      name
      instructions
      id
      isActive
      address {
        postalCode
        country
        city
        state
        neighborhood
        street
        number
        complement
        reference
        location {
          latitude
          longitude
          __typename
        }
        __typename
      }
      pickupHolidays {
        date
        hourBegin
        hourEnd
        __typename
      }
      businessHours {
        dayOfWeek
        openingTime
        closingTime
        __typename
      }
      __typename
    }
    paging {
      page
      pageSize
      total
      pages
      __typename
    }
    __typename
  }
}

variables:

{"postalCode":"*2*L*","pageNumber":1,"pageSize":50}

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
