### PR TITLE
Load store fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Falls back to Load All Stores if there's an error loading the closest stores
+
 ## [0.4.2] - 2020-11-19
 
 ### Fixed

--- a/react/List.tsx
+++ b/react/List.tsx
@@ -31,7 +31,12 @@ const StoreList = ({
   iconWidth,
   iconHeight,
 }) => {
-  const [getStores, { data, loading, called }] = useLazyQuery(GET_STORES)
+  const [getStores, { data, loading, called, error }] = useLazyQuery(
+    GET_STORES,
+    {
+      fetchPolicy: 'cache-first',
+    }
+  )
 
   const [state, setState] = useState({
     allLoaded: false,
@@ -59,7 +64,7 @@ const StoreList = ({
   if (ofCalled && !ofLoading && !called) {
     if (
       ofData.shippingData?.address?.postalCode &&
-      ofData.shippingData.address.postalCode.indexOf('*') !== -1
+      ofData.shippingData.address.postalCode.indexOf('*') === -1
     ) {
       getStores({
         variables: {
@@ -72,6 +77,10 @@ const StoreList = ({
     } else {
       loadAll()
     }
+  }
+
+  if (!loading && called && error && !state.allLoaded) {
+    loadAll()
   }
 
   const handleCenter = (center: any, zoom: number) => {


### PR DESCRIPTION
#### What problem is this solving?
If we have some error loading the closest stores, it don't load all stores instead

#### How to test it?
Enter a valid postalcode from England but try to load the stores from US

POST:  http://eriksbikeshop.{{environment}}.com.br/api/checkout/pub/orderForm/{{your-orderFormI}}/attachments/shippingData
```
{
  "address": {
    "postalCode": "WC2N 5DU",
    "country": "GBR"
  }
}
```
[Workspace](https://wender--eriksbikeshop.myvtex.com/stores)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
