### PR TITLE
Removed default title from the App's routes.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Fixed
-- Remove the Quick Order references from the doc
+
+- Removed default title from the App's `routes.json`
 
 ## [0.5.0] - 2020-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Removed
 
 - Removed default title from the App's `routes.json`
 

--- a/store/routes.json
+++ b/store/routes.json
@@ -1,11 +1,9 @@
 {
   "store.storelocator": {
-    "title": "Store Locator",
     "path": "/stores",
     "isSitemapEntry": true
   },
   "store.storedetail": {
-    "title": "Store Locator",
     "path": "/store/:slug/:store_id",
     "isSitemapEntry": false
   }


### PR DESCRIPTION
#### What problem is this solving?

Removed the default App's title from the `routes.json` file to allow the store to customize it from the Site Editor

