### PR TITLE
Wrap address and number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Wrap address and number
+- CSS Handless `addressStoreAddressGroupA`, `addressStoreAddressNumber`, `addressStoreAddressStreet`
 
 ## [0.8.0] - 2021-03-09
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -223,6 +223,9 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 |      `addressList`      |
 |  `addressStoreAddress`  |
 |   `addressStoreName`    |
+|  `addressStoreAddressGroupA`  |
+|  `addressStoreAddressNumber`  |
+|  `addressStoreAddressStreet`  |
 |   `backlinkContainer`   |
 |       `backlink`        |
 |     `businessHours`     |

--- a/react/StoreAddress.tsx
+++ b/react/StoreAddress.tsx
@@ -4,7 +4,14 @@ import { useCssHandles } from 'vtex.css-handles'
 
 import { useStoreGroup } from './StoreGroup'
 
-const CSS_HANDLES = ['addressContainer', 'addressLink', 'addressLabel'] as const
+const CSS_HANDLES = [
+  'addressContainer',
+  'addressLink',
+  'addressLabel',
+  'addressStoreAddressGroupA',
+  'addressStoreAddressNumber',
+  'addressStoreAddressStreet'
+] as const
 const messages = defineMessages({
   address: {
     defaultMessage: 'Store address',
@@ -41,8 +48,10 @@ const StoreAddress: FC<StoreAddressProps & WrappedComponentProps> = ({
         href={`https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}`}
       >
         <br />
-        {group.address.number ? `${group.address.number} ` : ''}
-        {`${group.address.street}`}
+        <span className={handles.addressStoreAddressGroupA}>
+          <span className={ handles.addressStoreAddressNumber }>{group.address.number ? `${group.address.number} ` : ''}</span>
+          <span className={ handles.addressStoreAddressStreet }>{`${group.address.street}`}</span>
+        </span>
         <br />
         {group.address.city ? `${group.address.city}` : ''}
         {group.address.state ? `, ${group.address.state}` : ''}

--- a/react/components/Listing.tsx
+++ b/react/components/Listing.tsx
@@ -15,7 +15,10 @@ const CSS_HANDLES = [
   'addressListFirstItem',
   'addressStoreName',
   'addressStoreAddress',
-  'addressListLink',
+  'addressStoreAddressGroupA',
+  'addressStoreAddressNumber',
+  'addressStoreAddressStreet',
+  'addressListLink'
 ] as const
 
 const Slugify = (str: string) => {
@@ -65,8 +68,10 @@ const Listing: FC<any> = ({ items, onChangeCenter }) => {
               </span>
               <br />
               <span className={`t-mini ${handles.addressStoreAddress}`}>
-                {item.address.number ? `${item.address.number} ` : ''}
-                {item.address.street}
+                <span className={handles.addressStoreAddressGroupA}>
+                  <span className={ handles.addressStoreAddressNumber }>{item.address.number ? `${item.address.number} ` : ''}</span>
+                  <span className={ handles.addressStoreAddressStreet }>{item.address.street}</span>
+                </span>
                 {item.address.city ? `, ${item.address.city}` : ''}
                 {item.address.state ? `, ${item.address.state}` : ''}
                 {item.address.postalCode ? ` - ${item.address.postalCode}` : ''}


### PR DESCRIPTION
#### What problem is this solving?

Wrap both texts (Address and Number) and add CSS Handless to customize them via CSS

#### How to test it?
[Workspace](https://www.partycity.com.mx/stores?workspace=ivanlopezluna)

#### Screenshots or example usage:
![Screenshot_20210617-143424](https://user-images.githubusercontent.com/23274114/122461762-6789ab00-cf79-11eb-9607-267ad2944c80.png)
![Screenshot_20210617-143513](https://user-images.githubusercontent.com/23274114/122461753-635d8d80-cf79-11eb-96d6-da156cf01000.png)

#### How does this PR make you feel? [:link:](https://media.giphy.com/media/A9grgCQ0Dm012/giphy.gif)
