### PR TITLE
[STORELOCAT-20] Add sortBy prop to store-list block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add sortBy prop to store-list block.
+- Fix latitude and longitude props to pinpoints and listing components.
+
 ## [0.10.9] - 2022-02-15
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -192,6 +192,7 @@ In order to define the Store Locator custom page UI, you must use the blocks exp
 |    `zoom`     | `number` |                                Map zoom as number.                                |          10           |
 |    `long`     | `number` |                       Longitude to be used as coordenates.                        |         null          |
 |     `lat`     | `number` |                       Lattitude to be used as coordenates.                        |         null          |
+|   `sortBy`    | `string` |        Property (`name` or `distance`) to be used to sort the stores list.        |       distance        |
 
 ℹ️ _If you have all your pick up points as in seller accounts ** you should provide `long` and `lat` props to show all seller stores** - if you don't have this props and you neither have pick up points the app will not show nothing._
 

--- a/react/List.tsx
+++ b/react/List.tsx
@@ -39,6 +39,7 @@ const StoreList = ({
   zoom,
   lat,
   long,
+  sortBy = 'distance',
 }) => {
   const [getStores, { data, loading, called, error }] = useLazyQuery(
     GET_STORES,
@@ -128,11 +129,11 @@ const StoreList = ({
 
     const stores =
       data?.getStores?.items.sort((a, b) => {
-        if (a.distance < b.distance) {
+        if (a[sortBy] < b[sortBy]) {
           return -1
         }
 
-        if (a.distance > b.distance) {
+        if (a[sortBy] > b[sortBy]) {
           return 1
         }
 

--- a/react/components/Listing.tsx
+++ b/react/components/Listing.tsx
@@ -2,7 +2,8 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import React, { FC } from 'react'
+import type { FC } from 'react'
+import React from 'react'
 import { injectIntl, FormattedMessage } from 'react-intl'
 import PropTypes from 'prop-types'
 import slugify from 'slugify'


### PR DESCRIPTION
#### What problem is this solving?

The client want to sort the stores list by name

#### How to test it?
1.- Download the store-theme installed in [this workspace](https://arturovtex--hersak.myvtex.com/stores)
2.-Add the `sortBy` prop, to the `store-list` block, it can accept the strings `name` or `distance`, by default will be distance.
3.- Link the downloaded store-theme to the workspace.
3.- See how the stores list is sorted by the new prop value.

[Workspace to test](https://arturovtex--hersak.myvtex.com/stores)
