### PR TITLE
[STORELOCAT-21] Add a vBase validation for sitemap to avoid duplicate…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a vBase validation for sitemap to avoid duplicated entries.
+
 ## [0.10.10] - 2022-04-20
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -22,17 +22,13 @@
     "vtex.css-handles": "0.x",
     "vtex.store-sitemap": "2.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "billingOptions": {
     "type": "free",
     "support": {
       "url": "https://support.vtex.com/hc/requests"
     },
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "policies": [
     {
@@ -61,6 +57,9 @@
     },
     {
       "name": "LogisticsViewer"
+    },
+    {
+      "name": "vbase-read-write"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/utils/Sitemap.ts
+++ b/node/utils/Sitemap.ts
@@ -20,7 +20,7 @@ export default class Sitemap extends AppGraphQLClient {
   public async saveIndex() {
     const { tenant } = this.context
 
-    this.graphql.mutate(
+    return this.graphql.mutate(
       {
         mutate: saveIndexMutation,
         variables: { index: 'store-locator' },


### PR DESCRIPTION
#### What problem is this solving?

Store locator app had a validation to check if the entry is already in the index, but the problem is that the mutation takes some time to be reflected, so it can be result in duplicated sitemap entries.

i'm adding a vBase validation for sitemap to check first the vBase before save again the same entry.

#### How to test it?

The easiest way to test this is cloning this branch and link in `sandboxusdev` in a new workspace, then write some console logs [here](https://github.com/vtex-apps/store-locator/blob/9505ea59a7f80f2ae25a0cfd9dddc66d503c65f7/node/graphql/index.ts#L92) to see the get response and check the if condition in order to save the index [here](https://github.com/vtex-apps/store-locator/blob/9505ea59a7f80f2ae25a0cfd9dddc66d503c65f7/node/graphql/index.ts#L94) should be executed.

Additionally you can change the value [here](https://github.com/vtex-apps/store-locator/blob/9505ea59a7f80f2ae25a0cfd9dddc66d503c65f7/node/utils/Sitemap.ts#L17) to force  the return to false in order to test the lines mentioned above.


