### PR TITLE
[STORELOCAT-25] Holiday exception hours updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.12] - 2022-08-04
 
+### Added
+- Add holiday exceptions
+
 ### Fixed
 
 - Destructuring error in vbase `alreadyHasSitemap` check

--- a/react/StoreHours.tsx
+++ b/react/StoreHours.tsx
@@ -103,26 +103,26 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
     const holiday = new Date(item.date)
     const dayOfWeek = holiday.getDay()
     const dayOfMonth = holiday.getDate()
-    const today = new Date();
+    const today = new Date()
 
-    if(today > holiday) {
+    if (today > holiday) {
       return ``
-    } else {
-      return (
-        <div className={`${handles.dayOfWeek} w-30`}>
-          {intl.formatMessage(messages[dayOfWeek])}, {dayOfMonth}
-        </div>
-      )
     }
+
+    return (
+      <div className={`${handles.dayOfWeek} w-30`}>
+        {intl.formatMessage(messages[dayOfWeek])}, {dayOfMonth}
+      </div>
+    )
   }
 
   const displayHolidayHours = (item) => {
     const open = timeFormat(item.hourBegin, format)
     const close = timeFormat(item.hourEnd, format)
     const holiday = new Date(item.date)
-    const today = new Date();
+    const today = new Date()
 
-    if(open == '' && close == '') {
+    if (open === '' && close === '') {
       return (
         <div className={`${handles.businessHours} tc w-50`}>
           {intl.formatMessage(messages.storeClosed)}
@@ -130,15 +130,15 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
       )
     }
 
-    if(today > holiday) {
+    if (today > holiday) {
       return ``
-    } else {
-      return (
-        <div className={`${handles.businessHours} tc w-50`}>
-          {open} - {close}
-        </div>
-      )
     }
+
+    return (
+      <div className={`${handles.businessHours} tc w-50`}>
+        {open} - {close}
+      </div>
+    )
   }
 
   return (
@@ -180,11 +180,12 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
             </div>
           )
         })}
-        <br />
-        <b>{intl.formatMessage(messages.holidayLabel)}</b>
-        {!pickupHolidays &&
+      <br />
+      <b>{intl.formatMessage(messages.holidayLabel)}</b>
+      {!pickupHolidays &&
         group.pickupHolidays.map((item: any, i: number) => (
-          <div key={`hour_${i}`}
+          <div
+            key={`hour_${i}`}
             className={`${handles.hourRow} mv1 flex flex-wrap`}
           >
             {displayHolidayDay(item)}
@@ -216,7 +217,7 @@ StoreHours.propTypes = {
     PropTypes.shape({
       date: PropTypes.string,
       hourBegin: PropTypes.string,
-      hourEnd: PropTypes.string
+      hourEnd: PropTypes.string,
     })
   ),
   intl: PropTypes.any,

--- a/react/StoreHours.tsx
+++ b/react/StoreHours.tsx
@@ -102,20 +102,20 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
   const displayHolidayDay = (item) => {
     const holiday = new Date(item.date)
     const dayOfWeek = holiday.getDay()
-    const dayOfMonth = holiday.getDate()
-    const month = new Intl.DateTimeFormat('US', { month: 'long' }).format(
-      holiday
-    )
+    const month = new Intl.DateTimeFormat('US', {
+      day: 'numeric',
+      month: 'long',
+    }).format(holiday)
 
     const today = new Date()
 
-    if (today > holiday) {
+    if (today >= holiday) {
       return ``
     }
 
     return (
       <div className={`${handles.dayOfWeek} w-30`}>
-        {intl.formatMessage(messages[dayOfWeek])}, {month} {dayOfMonth}
+        {intl.formatMessage(messages[dayOfWeek])}, {month}
       </div>
     )
   }

--- a/react/StoreHours.tsx
+++ b/react/StoreHours.tsx
@@ -103,6 +103,10 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
     const holiday = new Date(item.date)
     const dayOfWeek = holiday.getDay()
     const dayOfMonth = holiday.getDate()
+    const month = new Intl.DateTimeFormat('US', { month: 'long' }).format(
+      holiday
+    )
+
     const today = new Date()
 
     if (today > holiday) {
@@ -111,7 +115,7 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
 
     return (
       <div className={`${handles.dayOfWeek} w-30`}>
-        {intl.formatMessage(messages[dayOfWeek])}, {dayOfMonth}
+        {intl.formatMessage(messages[dayOfWeek])}, {month} {dayOfMonth}
       </div>
     )
   }

--- a/react/StoreHours.tsx
+++ b/react/StoreHours.tsx
@@ -101,6 +101,8 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
 
   const displayHolidayDay = (item) => {
     const holiday = new Date(item.date)
+
+    holiday.setDate(holiday.getDate() + 1)
     const dayOfWeek = holiday.getDay()
     const month = new Intl.DateTimeFormat('US', {
       day: 'numeric',
@@ -124,6 +126,8 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
     const open = timeFormat(item.hourBegin, format)
     const close = timeFormat(item.hourEnd, format)
     const holiday = new Date(item.date)
+
+    holiday.setDate(holiday.getDate() + 1)
     const today = new Date()
 
     if (open === '' && close === '') {

--- a/react/StoreHours.tsx
+++ b/react/StoreHours.tsx
@@ -11,6 +11,10 @@ const messages = defineMessages({
     defaultMessage: 'Store hours',
     id: 'store/hours-label',
   },
+  holidayLabel: {
+    defaultMessage: 'Holidays',
+    id: 'store/holidays-label',
+  },
   storeClosed: {
     defaultMessage: 'Closed',
     id: 'store/store-closed',
@@ -74,6 +78,7 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
   label,
   format,
   businessHours,
+  pickupHolidays,
   intl,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -92,6 +97,48 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
     }
 
     return `${open} - ${close}`
+  }
+
+  const displayHolidayDay = (item) => {
+    const holiday = new Date(item.date)
+    const dayOfWeek = holiday.getDay()
+    const dayOfMonth = holiday.getDate()
+    const today = new Date();
+
+    if(today > holiday) {
+      return ``
+    } else {
+      return (
+        <div className={`${handles.dayOfWeek} w-30`}>
+          {intl.formatMessage(messages[dayOfWeek])}, {dayOfMonth}
+        </div>
+      )
+    }
+  }
+
+  const displayHolidayHours = (item) => {
+    const open = timeFormat(item.hourBegin, format)
+    const close = timeFormat(item.hourEnd, format)
+    const holiday = new Date(item.date)
+    const today = new Date();
+
+    if(open == '' && close == '') {
+      return (
+        <div className={`${handles.businessHours} tc w-50`}>
+          {intl.formatMessage(messages.storeClosed)}
+        </div>
+      )
+    }
+
+    if(today > holiday) {
+      return ``
+    } else {
+      return (
+        <div className={`${handles.businessHours} tc w-50`}>
+          {open} - {close}
+        </div>
+      )
+    }
   }
 
   return (
@@ -133,6 +180,17 @@ const StoreHours: FC<WrappedComponentProps & StoreHoursProps> = ({
             </div>
           )
         })}
+        <br />
+        <b>{intl.formatMessage(messages.holidayLabel)}</b>
+        {!pickupHolidays &&
+        group.pickupHolidays.map((item: any, i: number) => (
+          <div key={`hour_${i}`}
+            className={`${handles.hourRow} mv1 flex flex-wrap`}
+          >
+            {displayHolidayDay(item)}
+            {displayHolidayHours(item)}
+          </div>
+        ))}
     </div>
   )
 }
@@ -141,6 +199,7 @@ interface StoreHoursProps {
   label?: string
   format?: string
   businessHours?: any
+  pickupHolidays?: any
 }
 
 StoreHours.propTypes = {
@@ -151,6 +210,13 @@ StoreHours.propTypes = {
       dayOfWeek: PropTypes.string,
       openingTime: PropTypes.string,
       closingTime: PropTypes.string,
+    })
+  ),
+  pickupHolidays: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.string,
+      hourBegin: PropTypes.string,
+      hourEnd: PropTypes.string
     })
   ),
   intl: PropTypes.any,

--- a/react/components/Map.tsx
+++ b/react/components/Map.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { GoogleMap, Marker, useJsApiLoader } from '@react-google-maps/api'
 
 const Map = (props: any) => {
-  const zoom = props.zoom
+  const { zoom } = props
   const { isLoaded } = useJsApiLoader({
     id: 'google-map-script',
     googleMapsApiKey: props.apiKey,

--- a/react/queries/getStore.gql
+++ b/react/queries/getStore.gql
@@ -5,6 +5,11 @@ query getStore($id: String!) {
       dayOfWeek
       closingTime
     }
+    pickupHolidays {
+      date
+      hourBegin
+      hourEnd
+    }
     isActive
     distance
     friendlyName

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -3,6 +3,11 @@ interface BusinessHours {
   dayOfWeek: string
   closingTime: string
 }
+interface HolidayHours {
+  date: string
+  hourBegin: string
+  hourEnd: string
+}
 interface Address {
   addressId: string
   cacheId: string
@@ -24,6 +29,7 @@ interface Address {
 }
 interface SpecificationGroup {
   businessHours: [BusinessHours]
+  pickupHolidays: [HolidayHours]
   isActive: boolean
   distance: number
   friendlyName: string


### PR DESCRIPTION
#### What problem is this solving?
- The store locator currently doesn't show any exception of hours or if is closed
- This was added in a separate section bellow the business hours

#### How to test it?
- You can test by visiting [this](https://beto--productusqa.myvtex.com/store/mexico-pickup-point-ciudad-de-mexico-03580/Mexico1) workspace

#### Screenshots or example usage:
![Image 2022-07-01 at 12 21 26 p m](https://user-images.githubusercontent.com/11176519/176941539-a2962179-c992-4a14-8bd8-6700c36ce0ac.jpg)

#### Image description
- The image shows only one holiday but there are 3 exception hours/holidays added
- One is that there are past holiday exceptions
- Another is that there is a valida holiday but without open and closing time (This will be set to closed)
- If there are business hours in this holiday then the hours will be set.