### PR TITLE
[STORELOCAT-30] App Review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- GitHub reusable workflow and Cy-Runner uptade to version 2
+- GitHub reusable workflow and Cy-Runner update to version 2
+- Updated descriptions for block props in README
+- Moved error logging for `getStores` to GraphQL resolver instead of client
 
 ## [0.10.13] - 2022-08-09
 
 ## [0.10.12] - 2022-08-04
 
 ### Added
+
 - Add holiday exceptions
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ The Store Locator app fetches the Pickup point data in order to display address 
 ## Configuration
 
 1. [Install](https://vtex.io/docs/recipes/development/installing-an-app/) the Store Locator app in your VTEX account by running `vtex install vtex.store-locator` in your terminal.
-2. In your account's admin page, select **Inventory&Shipping** section and then acess **Settings**.
+2. In your account's admin page, select **Inventory & Shipping** section and then access **Settings**.
 3. Type in the Google Geolocation API key and save your changes.
 4. Open your Store Theme app directory in your code editor.
 5. Add the Store Locator app as a `peerDependency` in the `manifest.json` file:
@@ -29,11 +29,11 @@ The Store Locator app fetches the Pickup point data in order to display address 
  }
 ```
 
-Once installed, the app will generate a new route called `/stores` for your store, listing the retail stores registered in the Pickup points section (under the Inventory & shipping module).
+Once installed, the app will generate a new route called `/stores` for your store, listing the retail stores registered in the **Pickup Points** section (under the **Inventory & Shipping** module).
 
-The new page already contains a default template with all blocks exported by the Store Locator app, meaning that the `/stores` page is ready to be rendered and no further actions are required. However, you can **customize the new page overwriting the template by creating a brand new one as you wish**. To do so, check the **Advanced configurations** section below.
+The new page already contains a default template with all blocks exported by the Store Locator app, meaning the `/stores` page is ready to be rendered and no further actions are required. However, you can **customize the new page overwriting the template by creating a brand new one**. To do so, check the [**Advanced configuration**](./README.md#advanced-configuration) section below.
 
-> ℹ️ _This app will also **add a new entry to your store's `/sitemap.xml` file in order to have all the pickup points available to the search engines** - make sure you already have the `vtex.store-sitemap@2.x` app installed in your VTEX account!_
+> ℹ️ _This app will also **add a new entry to your store's `/sitemap.xml` file so that all your pickup points are available to search engines** - make sure you already have the `vtex.store-sitemap@2.x` app installed in your VTEX account!_
 
 ### Advanced configuration
 
@@ -41,17 +41,17 @@ In order to define the Store Locator custom page UI, you must use the blocks exp
 
 |      Block name      |                                                                              Description                                                                              |
 | :------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-|     `store-list`     |                                                Renders a list of retail stores and a map with all their localization.                                                 |
-|    `store-group`     |                                  Provides the pickup point data to other blocks exported by the app, such as the ones listed below.                                   |
+|     `store-list`     |                                              Renders a list of retail stores and a map with all their locations marked.                                               |
+|    `store-group`     |                                  Provides the Pickup Point data to other blocks exported by the app, such as the ones listed below.                                   |
 |     `store-name`     |                                                                        Renders the store name.                                                                        |
 |  `store-back-link`   |                                                            Renders a link to return to the previous page.                                                             |
-|     `store-map`      |                                                           Renders a map with the retail store localization.                                                           |
+|     `store-map`      |                                                            Renders a map with the retail store's location.                                                            |
 |   `store-address`    |                                                                     Renders the store's address.                                                                      |
 |    `store-hours`     | Renders the store's opening hours. This information comes by default from the Pickup Points configuration, but you can also define manually through the Store's theme |
 | `store-instructions` |                                                     Renders the desired instructions to access the retail store.                                                      |
 
 1. Open your Store Theme app directory in your code editor.
-2. In the `store/blocks` folder of your Store Theme app, create a new file called `storelocator.json`.
+2. In the `/store/blocks` folder of your Store Theme app, create a new file called `storelocator.json`.
 3. Create a new store template in it called `store.storelocator`. In its blocks array, paste the default implementation stated below:
 
 ```json
@@ -183,77 +183,79 @@ In order to define the Store Locator custom page UI, you must use the blocks exp
 
 #### `store-list`
 
-|   Prop name   |   Type   |                                    Description                                    |     Default value     |
-| :-----------: | :------: | :-------------------------------------------------------------------------------: | :-------------------: |
-| `filterByTag` | `string` |      Desired tags to filter the Pickup Points fetched and displayed. You can      |      `undefined`      |
-|    `icon`     | `string` | Icon URL (`svg` or `png`) to be displayed alongside with the `store-list` blocks. |   Google's default.   |
-|  `iconWidth`  | `number` |                           Icon width in pixels (`px`).                            | Image default width.  |
-| `iconHeight`  | `number` |                           Icon height in pixels (`px`).                           | Image default height. |
-|    `zoom`     | `number` |                                Map zoom as number.                                |          10           |
-|    `long`     | `number` |                       Longitude to be used as coordenates.                        |         null          |
-|     `lat`     | `number` |                       Lattitude to be used as coordenates.                        |         null          |
-|   `sortBy`    | `string` |        Property (`name` or `distance`) to be used to sort the stores list.        |       distance        |
+|   Prop name   |   Type   |                                 Description                                  |    Default value     |
+| :-----------: | :------: | :--------------------------------------------------------------------------: | :------------------: |
+| `filterByTag` | `string` |                  Filter fetched Pickup Points by this tag.                   |      undefined       |
+|    `icon`     | `string` | Icon used to display store location in map. Input icon URL (`svg` or `png`). |   Google's default   |
+|  `iconWidth`  | `number` |                         Icon width in pixels (`px`).                         | Image default width  |
+| `iconHeight`  | `number` |                        Icon height in pixels (`px`).                         | Image default height |
+|    `zoom`     | `number` |                            Map zoom as a number.                             |         `10`         |
+|     `lat`     | `number` |                             Latitude coordinate.                             |      undefined       |
+|    `long`     | `number` |                            Longitude coordinate.                             |      undefined       |
+|   `sortBy`    | `string` |        Property (`name` or `distance`) used to sort the stores list.         |      `distance`      |
 
-ℹ️ _If you have all your pick up points as in seller accounts ** you should provide `long` and `lat` props to show all seller stores** - if you don't have this props and you neither have pick up points the app will not show nothing._
+> ℹ️ _Use the `lat` and `long` props to display Pickup Points configured in seller accounts. If these props are not configured and you do not have any pick up points set up in your main account, the app will display no stores._
+
+> ℹ️ _The `filterByTag` prop cannot be used along with `lat` and `long`. If you set a value for `filterByTag`, the `lat` and `long` props will be ignored._
 
 #### `store-group` props
 
 |       Prop name       |   Type    |                                                                                                                     Description                                                                                                                      | Default value |
 | :-------------------: | :-------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----------: |
-|        `title`        | `string`  |                                              Title text to be displayed on the store page. Use `{storeName}`, `{storeCity}`, or `{storeState}` as value to display the store's accurate data on the UI.                                              | `{storeName}` |
-|     `description`     | `string`  |                                       Page description used in the page's Structured Data for SEO purposes. The `{storeName}`, `{storeCity}`, or `{storeState}` variables can be used in the description text.                                       |      ``       |
-|    `imageSelector`    | `string`  |                                                                                           CSS Selector that will wrap all the images displayed on the UI.                                                                                            |  `undefined`  |
+|        `title`        | `string`  |                                  Title used in the page's HTML `title` tag and Structured Data for SEO purposes. The `{storeName}`, `{storeCity}`, and / or `{storeState}` variables can be used in the title text.                                  | `{storeName}` |
+|     `description`     | `string`  |                    Description text used in the page's HTML `description` meta tag and Structured Data for SEO purposes. The `{storeName}`, `{storeCity}`, and / or `{storeState}` variables can be used in the description text.                    | empty string  |
+|    `imageSelector`    | `string`  |                                                                                      CSS Selector to select the images included in the page's Structured Data.                                                                                       | empty string  |
 | `instructionsAsPhone` | `boolean` | To provide a unique phone number for each store, a phone number can be entered in the `Instructions` field in the Pickup Points section. The `store-instructions` will display a phone number and it will be included in the page's Structured Data. |    `false`    |
 
-> ⚠️ _Both `imageSelector` and `instructionsAsPhone` must be declared with valid values in order to provide Structured Data for SEO purposes._
+⚠️ _Both `imageSelector` and `instructionsAsPhone` must be declared with valid values in order to provide Structured Data for SEO purposes._
 
 #### `store-name` props
 
-| Prop name |   Type   |                                                                           Description                                                                            | Default value |
-| :-------: | :------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----------: |
-|  `text`   | `string` | Text to be displayed alongside with the store name. Use `{storeName}`, `{storeCity}`, or `{storeState}` as value to display the store's accurate data on the UI. |               |
-|   `tag`   | `string` |                                               HTML element to wrap the `store-name` block when rendered on the UI.                                               |     `div`     |
+| Prop name |   Type   |                                                               Description                                                                | Default value |
+| :-------: | :------: | :--------------------------------------------------------------------------------------------------------------------------------------: | :-----------: |
+|  `text`   | `string` | Text to be displayed as store name. `{storeName}`, `{storeCity}`, and / or `{storeState}` values can be used to generate the store name. |   undefined   |
+|   `tag`   | `string` |                                   HTML element to wrap the `store-name` block when rendered on the UI.                                   |     `div`     |
 
 #### `store-back-link` props
 
-| Prop name |   Type   |                          Description                          |    Default value     |
-| :-------: | :------: | :-----------------------------------------------------------: | :------------------: |
-|  `label`  | `string` | Entitles the `store-back-link` block when rendered on the UI. | `Back to all stores` |
+| Prop name |   Type   |                            Description                             |    Default value     |
+| :-------: | :------: | :----------------------------------------------------------------: | :------------------: |
+|  `label`  | `string` | Text displayed by `store-back-link` block when rendered on the UI. | `Back to all stores` |
 
 #### `store-map` props
 
-| Prop name |   Type    |                                   Description                                    |   Default value   |
-| :-------: | :-------: | :------------------------------------------------------------------------------: | :---------------: |
-|  `width`  | `string`  |                           Map width in pixels (`px`).                            |      `100%`       |
-| `height`  | `string`  |                           Map height in pixels (`px`).                           |      `200px`      |
-|  `zoom`   | `integer` |                               Map zoom as `number`                               |       `14`        |
-|  `icon`   | `string`  | Icon URL (`svg` or `png`) to be displayed alongside with the `store-map` blocks. | Google's default. |
+| Prop name |   Type    |                                 Description                                  | Default value |
+| :-------: | :-------: | :--------------------------------------------------------------------------: | :-----------: |
+|  `width`  | `string`  |                                  Map width.                                  |    `100%`     |
+| `height`  | `string`  |                                 Map height.                                  |    `200px`    |
+|  `zoom`   | `integer` |                            Map zoom as a `number`                            |     `14`      |
+|  `icon`   | `string`  | Icon used to display store location in map. Input icon URL (`svg` or `png`). |   undefined   |
 
 #### `store-address` props
 
-| Prop name |   Type   |                         Description                         |  Default value  |
-| :-------: | :------: | :---------------------------------------------------------: | :-------------: |
-|  `label`  | `string` | Entitles the `store-address` block when rendered on the UI. | `Store address` |
+| Prop name |   Type   |                         Description                          |  Default value  |
+| :-------: | :------: | :----------------------------------------------------------: | :-------------: |
+|  `label`  | `string` | Label for the `store-address` block when rendered on the UI. | `Store address` |
 
 #### `store-hours` props
 
 |    Prop name    |       Type        |                                    Description                                    | Default value. |
 | :-------------: | :---------------: | :-------------------------------------------------------------------------------: | :------------: |
-|     `label`     |     `string`      |             Entitles the `store-hours` block when rendered on the UI.             | `Store hours`  |
-|    `format`     |      `enum`       |                Hour format. Possible values are : `12h` and `24h`.                |     `24h`      |
-| `businessHours` | `array of object` | format `{"dayOfWeek": "Sunday","openingTime": "11:00am","closingTime": "5:00pm"}` |  `undefined`   |
+|     `label`     |     `string`      |            Label for the `store-hours` block when rendered on the UI.             | `Store hours`  |
+|    `format`     |      `enum`       |                 Hour format. Possible values are `12h` and `24h`.                 |     `24h`      |
+| `businessHours` | `array of object` | format `{"dayOfWeek": "Sunday","openingTime": "11:00am","closingTime": "5:00pm"}` |   undefined    |
 
 #### `store-description` props
 
 | Prop name |   Type   |                                                                     Description                                                                      | Default value |
 | :-------: | :------: | :--------------------------------------------------------------------------------------------------------------------------------------------------: | :-----------: |
-|  `text`   | `string` | Text to be displayed on the store page. Use `{storeName}`, `{storeCity}`, or `{storeState}` within your text to display that store's specific value. |               |
+|  `text`   | `string` | Text to be displayed on the store page. Use `{storeName}`, `{storeCity}`, or `{storeState}` within your text to display that store's specific value. |   undefined   |
 
 #### `store-instructions` props
 
-| Prop name |   Type   |                           Description                            | Default value |
-| :-------: | :------: | :--------------------------------------------------------------: | :-----------: |
-|  `label`  | `string` | Entitles the `store-instructions` block when rendered on the UI. | `Information` |
+| Prop name |   Type   |                            Description                            | Default value |
+| :-------: | :------: | :---------------------------------------------------------------: | :-----------: |
+|  `label`  | `string` | Label for the `store-instructions` block when rendered on the UI. | `Information` |
 
 ## Customization
 

--- a/node/graphql/index.ts
+++ b/node/graphql/index.ts
@@ -9,6 +9,10 @@ const Slugify = (str: string) => {
   return slugify(str, { lower: true, remove: /[*+~.()'"!:@]/g })
 }
 
+const stripTrailingSlash = (str: string) => {
+  return str.endsWith('/') ? str.slice(0, -1) : str
+}
+
 export const resolvers = {
   Routes: {
     getSitemap: [
@@ -16,6 +20,7 @@ export const resolvers = {
         GET: async (ctx: Context) => {
           const {
             clients: { tenant },
+            vtex: { logger },
           } = ctx
 
           try {
@@ -27,7 +32,11 @@ export const resolvers = {
                 longitude: null,
               },
               ctx
-            )
+            ).catch((error) => {
+              logger.error({ error, message: 'getSitemap-getStores-error' })
+
+              return null
+            })
 
             const [storeBindings] = await getStoreBindings(tenant)
 
@@ -36,10 +45,6 @@ export const resolvers = {
               canonicalBaseAddress.indexOf('myvtex') === -1
                 ? String(canonicalBaseAddress)
                 : String(ctx.vtex.host)
-
-            const stripTrailingSlash = (str: string) => {
-              return str.endsWith('/') ? str.slice(0, -1) : str
-            }
 
             const lastMod = new Date().toISOString()
             const storesMap = `
@@ -117,12 +122,29 @@ export const resolvers = {
         }
       })
 
-      let result = await hub.getStores(param)
+      let result = await hub.getStores(param).catch((error) => {
+        logger.error({
+          error,
+          message: 'getStores-error',
+          param,
+        })
+
+        return null
+      })
 
       if (!result?.data.length && !param.keyword) {
-        result = await hub.getStores({})
+        result = await hub.getStores({}).catch((error) => {
+          logger.error({
+            error,
+            message: 'getStores-error',
+            param: {},
+          })
+
+          return null
+        })
       }
 
+      // accounts for different reponse structure for Logistics _search and _searchsellers endpoints
       const {
         data,
         data: { paging = { pages: 0 } },
@@ -136,7 +158,17 @@ export const resolvers = {
       const limitPagesTo99 = paging.pages > 99 ? 99 : paging.pages
 
       for (let i = 2; i <= limitPagesTo99; i++) {
-        results.push(hub.getStores({ ...param, page: i }))
+        results.push(
+          hub.getStores({ ...param, page: i }).catch((error) => {
+            logger.error({
+              error,
+              message: 'getStores-error',
+              param: { ...param, page: i },
+            })
+
+            return null
+          })
+        )
       }
 
       const remainingData = await Promise.all(results)

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   ClientsConfig,
-  Service,
   ServiceContext,
   ParamsContext,
   RecorderState,
 } from '@vtex/api'
+import { Service } from '@vtex/api'
 
 import { Clients } from './clients'
 import { resolvers } from './graphql'

--- a/node/utils/Binding.ts
+++ b/node/utils/Binding.ts
@@ -1,4 +1,4 @@
-import { TenantClient } from '@vtex/api'
+import type { TenantClient } from '@vtex/api'
 
 export const TENANT_CACHE_TTL_S = 60 * 10
 export const STORE_PRODUCT = 'vtex-storefront'

--- a/node/utils/Hub.ts
+++ b/node/utils/Hub.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ExternalClient, InstanceOptions, IOContext, Logger } from '@vtex/api'
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { ExternalClient } from '@vtex/api'
 
 const BASE_PATH =
   'http://logistics.vtexcommercestable.com.br/api/logistics/pvt/configuration/pickuppoints/'
@@ -26,7 +27,6 @@ const routes = {
 }
 
 export default class RequestHub extends ExternalClient {
-  public logger: Logger
   constructor(context: IOContext, options?: InstanceOptions) {
     super('', context, {
       ...options,
@@ -37,16 +37,9 @@ export default class RequestHub extends ExternalClient {
         VtexIdclientAutCookie: context.authToken,
       },
     })
-    this.logger = new Logger(context)
   }
 
   public getStores(data: any) {
-    return this.http
-      .getRaw(routes.getAll(data, this.context.account))
-      .catch((e) => {
-        this.logger.error({ error: e, message: 'getStores-error' })
-
-        return null
-      })
+    return this.http.getRaw(routes.getAll(data, this.context.account))
   }
 }

--- a/node/utils/Sitemap.ts
+++ b/node/utils/Sitemap.ts
@@ -1,4 +1,5 @@
-import { AppGraphQLClient, InstanceOptions, IOContext } from '@vtex/api'
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { AppGraphQLClient } from '@vtex/api'
 
 const saveIndexMutation = `mutation SaveIndex($index: String!) {
     saveIndex(index: $index)
@@ -27,7 +28,7 @@ export default class Sitemap extends AppGraphQLClient {
       },
       {
         headers: {
-          ...(this.options && this.options.headers),
+          ...this.options?.headers,
           'Proxy-Authorization': this.context.authToken,
           VtexIdclientAutCookie: this.context.authToken,
           'x-vtex-tenant': tenant,


### PR DESCRIPTION
#### What problem is this solving?

App review changes per [checklist in Notion](https://www.notion.so/vtexhandbook/2022-Q3-App-Review-Checklist-a68487945f864ce0a2b216a43d31efa3):

- Moved error handling for `getStores` to GraphQL resolver instead of keeping in client
- Updated README for clarity

#### How to test it?

Test in workspace [anna](https://anna--eriksbikeshop.myvtex.com/stores) by accessing the stores list and store details pages.

Or run the `getStores` query in the GraphQL IDE. Use arguments `latitude: 44.88, longitude: -93.25`, `keyword: "SD"`, or no arguments.

```
query{
  getStores(keyword: "SD"){
    items{
      name
    }
  }
}
```

#### Screenshots or example usage:
`getStores` query is working in the workspace
<img width="1440" alt="Screen Shot 2022-10-05 at 6 04 20 PM" src="https://user-images.githubusercontent.com/53097865/194172516-a18a5104-3188-4005-98d7-89706d728738.png">

