### PR TITLE
Update List.tsx

### DIFF
--- a/react/List.tsx
+++ b/react/List.tsx
@@ -123,7 +123,10 @@ const StoreList: FunctionComponent<WrappedComponentProps & Props> = ({
 
     const { latitude, longitude } = firstResult.address.location
 
-    const center = ofData?.orderForm?.shippingData?.address?.geoCoordinates ?? [
+    const ofGeoCoordinates = ofData?.orderForm?.shippingData?.address?.geoCoordinates
+    const center = (ofGeoCoordinates && ofGeoCoordinates.length > 0)
+    ? ofGeoCoordinates
+    : [
       longitude || long,
       latitude || lat,
     ]


### PR DESCRIPTION
Add condition to check if geoCoordinates array in orderForm is not empty before assigning it to center.

#### What problem is this solving?

If orderForm has addresses only with postal codes and no geoCoordinates, the center map function fails. Hence, it must first check if the used array is not actually empty.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[dndstorelocator](https://dndstorelocator--dunnesstorespreprod.myvtex.com)
