### PR TITLE
Fix/removing billing options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Removing billing options in order to use store-locator as a direct dependency.
+
 ## [0.11.1] - 2023-11-07
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -25,15 +25,6 @@
   "registries": [
     "smartcheckout"
   ],
-  "billingOptions": {
-    "type": "free",
-    "support": {
-      "url": "https://support.vtex.com/hc/requests"
-    },
-    "availableCountries": [
-      "*"
-    ]
-  },
   "policies": [
     {
       "name": "outbound-access",


### PR DESCRIPTION
Removing billing options from manifest.js in order to use this app as a direct dependency in a store-theme project