### PR TITLE
EDU-13628 - Store Locator is no longer maintained by VTEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a callout to inform users that the Store Locator app is no longer maintained by VTEX.
+
 ## [1.0.0] - 2024-10-21
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,11 @@
 
 # Store Locator
 
+##  ⚠️ Maintenance ⚠️
+*Starting June 1st 2023, this application will no longer be maintained by VTEX.*
+
+---
+
 <!-- DOCS-IGNORE:start -->
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 
@@ -9,8 +14,6 @@
 
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <!-- DOCS-IGNORE:end -->
-
->❗️ The `vtex.store-locator` app is no longer maintained by VTEX.
 
 The Store Locator app fetches the Pickup point data in order to display address location for retail stores.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <!-- DOCS-IGNORE:end -->
 
+>❗️ The `vtex.store-locator` app is no longer maintained by VTEX.
+
 The Store Locator app fetches the Pickup point data in order to display address location for retail stores.
 
 ![store-list](https://user-images.githubusercontent.com/52087100/99975140-9f809500-2d80-11eb-87ce-2f9cfcf567d6.png)


### PR DESCRIPTION
#### What problem is this solving?

- Adding a callout to inform users that the Store Locator app is no longer maintained by VTEX

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
